### PR TITLE
support Ruby 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       celluloid-io (>= 0.15.0)
       http_parser.rb (>= 0.6.0.beta.2)
       rack (>= 1.4.5)
-    nio4r (1.0.0)
+    nio4r (1.1.0)
     polyglot (0.3.5)
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)


### PR DESCRIPTION
checked on Yosemite 10.10.2 with ruby:
- 2.0.0
- 2.1.5
- 2.2.0
